### PR TITLE
Merge SS5 branch (2) into SS6 branch (3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,3 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
-    with:
-      phpcoverage: true

--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,5 @@
             "silverstripe/vendor-plugin": true
         },
         "process-timeout": 600
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.x-dev"
-        }
     }
 }

--- a/src/Element/ElementCallToAction.php
+++ b/src/Element/ElementCallToAction.php
@@ -38,6 +38,13 @@ class ElementCallToAction extends ElementContent
     ];
 
     /**
+     * @var array
+     */
+    private static $owns = [
+        'CtaLink',
+    ];
+
+    /**
      * @return FieldList
      */
     public function getCMSFields(): FieldList

--- a/src/Element/ElementCallToAction.php
+++ b/src/Element/ElementCallToAction.php
@@ -23,7 +23,7 @@ class ElementCallToAction extends ElementContent
     /**
      * @var string
      */
-    private static string $plural_name = 'Call to Actions';
+    private static string $plural_name = 'Call to Action Blocks';
 
     /**
      * @var string
@@ -67,13 +67,5 @@ class ElementCallToAction extends ElementContent
     public function getSummary(): string
     {
         return DBField::create_field('HTMLText', $this->HTML)->Summary(20);
-    }
-
-    /**
-     * @return string
-     */
-    public function getType(): string
-    {
-        return _t(__CLASS__ . '.BlockType', 'Call To Action');
     }
 }

--- a/src/Element/ElementCallToAction.php
+++ b/src/Element/ElementCallToAction.php
@@ -68,4 +68,15 @@ class ElementCallToAction extends ElementContent
     {
         return DBField::create_field('HTMLText', $this->HTML)->Summary(20);
     }
+
+    /**
+     * Override getType() because ElementContent hardcodes 'Content'.
+     * Use singular_name() to allow extensibility while overriding parent behavior.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return _t(__CLASS__ . '.BlockType', $this->singular_name());
+    }
 }


### PR DESCRIPTION
## Summary

Merge the SS5 branch into the SS6 branch to bring forward the `getType()` refactor changes.

## Changes from SS5 branch

- Removed `getType()` method override to allow extensibility via `$singular_name`
- Updated `$plural_name` value

## Related

- Original SS5 PR: #11
- Parent issue: dynamic/silverstripe-essentials-tools#68