### PR TITLE
REFACTOR: Remove getType() override for extensibility

### DIFF
--- a/src/Element/ElementCallToAction.php
+++ b/src/Element/ElementCallToAction.php
@@ -23,7 +23,7 @@ class ElementCallToAction extends ElementContent
     /**
      * @var string
      */
-    private static string $plural_name = 'Call to Actions';
+    private static string $plural_name = 'Call to Action Blocks';
 
     /**
      * @var string
@@ -67,13 +67,5 @@ class ElementCallToAction extends ElementContent
     public function getSummary(): string
     {
         return DBField::create_field('HTMLText', $this->HTML)->Summary(20);
-    }
-
-    /**
-     * @return string
-     */
-    public function getType(): string
-    {
-        return _t(__CLASS__ . '.BlockType', 'Call To Action');
     }
 }


### PR DESCRIPTION
Remove `getType()` override from `ElementCallToAction` to allow extensibility via `$singular_name` config.

## Changes

- Removed `getType()` method override
- Relies on existing `$singular_name = 'Call to Action'` config

## Rationale

`BaseElement::getType()` uses `i18n_singular_name()` which respects the `$singular_name` config:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

Note: While `ElementCallToAction` extends `ElementContent` (which hardcodes 'Content' in its `getType()`), removing this override means the element will now display as "Call to Action" from `$singular_name` rather than needing a custom override.

Extensions can now customize display names by simply setting `$singular_name` config instead of overriding the method.