### PR TITLE
fix(#4): use $CtaLink instead of $LinkObject in template

### DIFF
--- a/templates/Dynamic/Elements/CTA/Elements/ElementCallToAction.ss
+++ b/templates/Dynamic/Elements/CTA/Elements/ElementCallToAction.ss
@@ -8,7 +8,7 @@
                 <% end_if %>
                 <% if $CtaLink %>
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center content-element_ctalink">
-                        <% with $LinkObject %>
+                        <% with $CtaLink %>
                             <a href="$URL" <% if $OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %> class="btn btn-primary">$Title</a>
                         <% end_with %>
                     </div>

--- a/templates/Dynamic/Elements/CTA/Elements/ElementCallToAction.ss
+++ b/templates/Dynamic/Elements/CTA/Elements/ElementCallToAction.ss
@@ -8,9 +8,7 @@
                 <% end_if %>
                 <% if $CtaLink %>
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center content-element_ctalink">
-                        <% with $CtaLink %>
-                            <a href="$URL" <% if $OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %> class="btn btn-primary">$Title</a>
-                        <% end_with %>
+                        <a href="$CtaLink.URL" <% if $CtaLink.OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %> class="btn btn-primary">$CtaLink.Title</a>
                     </div>
                 <% end_if %>
             </div>


### PR DESCRIPTION
## Summary

- Template used `<% with $LinkObject %>` but the `has_one` relation is named `CtaLink`
- `$LinkObject` doesn't exist on this class, so the `<% with %>` block evaluated against a null context and the link was never rendered
- One-character rename to `<% with $CtaLink %>`

Closes #4